### PR TITLE
Use lein-ring for better dev server experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Lewis
 =====
 
@@ -13,10 +12,10 @@ Clone the repo and then run Lewis with Leiningen.
 ```
 git clone https://github.com/rodnaph/lewis.git
 cd lewis
-lein run
+lein ring server
 ```
 
-You can then open your browser to _http://localhost:5555_, and you
+Your  browser will automatically open to _http://localhost:5555_, and you
 should see the web interface where you can connect.  Just enter the
 Datomic URI to your database.
 
@@ -54,10 +53,14 @@ the schema attributes you want, and the EDN is created for you below.
 
 ![](http://github.com/rodnaph/lewis/raw/master/screenshots/update.png)
 
+Production
+==========
+
+To use in production, run `lein run` in the main directory to launch a jetty server.
+
 TODO
 ====
 
 I'm hacking on this project to learn more about Datomic, so not even sure if what I've
 done so far is useful (or makes sense).  Making up features as I go then...  but if
 you do have any ideas please just open an issue or get in touch.
-

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,3 @@
-
 (defproject lewis "0.0.1"
   :description "Web interface for Datomic"
   :dependencies [[org.clojure/clojure "1.4.0"]
@@ -8,5 +7,12 @@
                  [hiccup "1.0.1"]
                  [cheshire "4.0.3"]
                  [com.datomic/datomic-free "0.8.3551"]]
-  :main lewis.core)
 
+  :main lewis.core
+
+  :plugins [[lein-ring "0.8.8"]]
+
+  :ring {:handler lewis.web/app
+         :port 5555
+         :auto-refresh true
+         :nrepl {:start? true}})

--- a/src/lewis/actions.clj
+++ b/src/lewis/actions.clj
@@ -1,4 +1,3 @@
-
 (ns lewis.actions
   (:require [lewis.db :as db]
             [ring.util.response :as response]))

--- a/src/lewis/core.clj
+++ b/src/lewis/core.clj
@@ -1,7 +1,6 @@
-
 (ns lewis.core
-  (:require [ring.adapter.jetty :as jetty]
-            [lewis.web :as web]))
+  (:require [lewis.web :as web]
+            [ring.adapter.jetty :as jetty]))
 
 (defn -main [& args]
   (jetty/run-jetty 

--- a/src/lewis/data/core.clj
+++ b/src/lewis/data/core.clj
@@ -1,12 +1,9 @@
-
 (ns lewis.data.core
-  (:use (hiccup form)
-        [datomic.api :only [q] :as d])
-  (:require (lewis [db :as db]
-                   [results :as results]
-                   [layout :as layout]
-                   [form :as form]
-                   [history :as history])))
+  (:require [hiccup.form :refer :all]
+            [lewis.form :as form]
+            [lewis.history :as history]
+            [lewis.layout :as layout]
+            [lewis.results :as results]))
 
 ;; Public
 ;; ------

--- a/src/lewis/db.clj
+++ b/src/lewis/db.clj
@@ -1,6 +1,5 @@
-
 (ns lewis.db
-  (:use [datomic.api :only [q db] :as d]))
+  (:require [datomic.api :as d :refer [db]]))
 
 (def ^:dynamic cnn (atom nil)) 
 

--- a/src/lewis/form.clj
+++ b/src/lewis/form.clj
@@ -1,6 +1,5 @@
-
 (ns lewis.form
-  (:use (hiccup core form)))
+  (:require [hiccup.form :refer :all]))
 
 (declare submit)
                   

--- a/src/lewis/history.clj
+++ b/src/lewis/history.clj
@@ -1,4 +1,3 @@
-
 (ns lewis.history)
 
 (def qs (ref []))

--- a/src/lewis/layout.clj
+++ b/src/lewis/layout.clj
@@ -1,7 +1,6 @@
-
 (ns lewis.layout
-  (:use (hiccup core page))
-  (:require [lewis.session :as session]))
+  (:require [hiccup.page :refer :all]
+            [lewis.session :as session]))
 
 (defn standard [title & content]
   (let [home-url (if (session/exists) "/session" "/")]

--- a/src/lewis/pages.clj
+++ b/src/lewis/pages.clj
@@ -1,11 +1,7 @@
-
 (ns lewis.pages
-  (:use [datomic.api :only [q] :as d])
-  (:require [lewis.layout :as layout]
-            [lewis.form :as form]
-            [lewis.results :as results]
-            [lewis.db :as db]
-            [lewis.history :as history]))
+  (:require [lewis.form :as form]
+            [lewis.history :as history]
+            [lewis.layout :as layout]))
 
 (defn- to-recent-query [tx]
   (let [url (format "/session/data?tx=%s" tx)]

--- a/src/lewis/results.clj
+++ b/src/lewis/results.clj
@@ -1,7 +1,6 @@
-
 (ns lewis.results
-  (:use [datomic.api :only [q] :as d])
-  (:require [lewis.db :as db]))
+  (:require [datomic.api :as d :refer [q]]
+            [lewis.db :as db]))
 
 (declare id2entity)
 

--- a/src/lewis/schema/core.clj
+++ b/src/lewis/schema/core.clj
@@ -1,13 +1,12 @@
-
 (ns lewis.schema.core
-  (:use (hiccup form)
-        [datomic.api :only [q] :as d])
   (:require [cheshire.core :as json]
-            [ring.util.response :as response]
-            [lewis.layout :as layout]
+            [datomic.api :as d :refer [q]]
+            [hiccup.form :refer :all]
+            [lewis.db :as db]
             [lewis.form :as form]
+            [lewis.layout :as layout]
             [lewis.results :as results]
-            [lewis.db :as db]))
+            [ring.util.response :as response]))
 
 (def schema-tx '[:find ?e 
                  :where [?e :db/valueType]])

--- a/src/lewis/session.clj
+++ b/src/lewis/session.clj
@@ -1,4 +1,3 @@
-
 (ns lewis.session
   (:require [ring.util.response :as response]))
 

--- a/src/lewis/web.clj
+++ b/src/lewis/web.clj
@@ -1,15 +1,14 @@
-
 (ns lewis.web
-  (:use compojure.core
-        (ring.middleware reload stacktrace))
-  (:require (compojure [handler :as handler]
-                       [route :as route])
-            [ring.util.response :as response]
-            (lewis [pages :as pages]
-                   [session :as session]
-                   [actions :as actions])
+  (:require [compojure.core :refer :all]
+            [compojure.handler :as handler]
+            [compojure.route :as route]
+            [lewis.actions :as actions]
             [lewis.data.core :as data]
-            [lewis.schema.core :as schema]))
+            [lewis.pages :as pages]
+            [lewis.schema.core :as schema]
+            [lewis.session :as session]
+            [ring.middleware.reload :refer :all]
+            [ring.middleware.stacktrace :refer :all]))
 
 (defroutes session-routes
   (GET "/" [] pages/home)


### PR DESCRIPTION
- runs nrepl automatically
- opens page automatically when run with `lein ring server`
- maintains ability to execute with `lein run`; alternatively, can use
  `lein ring server-headless` for similar behavior.
- Fixes #6.
- Depends on #8.
